### PR TITLE
Default to implementation1

### DIFF
--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: featureflag-example
   annotations:
-    businessFeature: implementation2
+    businessFeature: implementation1
 spec:
   containers:
   - name: app


### PR DESCRIPTION
Code also defaults to implementation1: https://github.com/gardener-samples/kube-featureflag/blob/master/src/index.js#L32

If we don't set the default in the annotations as well, annotation will have `implementation2` set, but the file never changes, therefore the code will continue to call `implementation1`